### PR TITLE
Thought this change would be helpful

### DIFF
--- a/application/libraries/tweet.php
+++ b/application/libraries/tweet.php
@@ -277,7 +277,10 @@
 		
 		private $_obj;
 		private $_tokens = array();
-		private $_authorizationUrl 	= 'http://api.twitter.com/oauth/authorize';
+
+		// I changed the url of $_authorizationUrl to 'authenticate' instead of 'authorize' as if a user has already authed an app
+		// To their account- this URL auto logs them instead of asking for permission again... much better for "sign in" type apps
+		private $_authorizationUrl 	= 'http://twitter.com/oauth/authenticate';
 		private $_requestTokenUrl 	= 'http://api.twitter.com/oauth/request_token';
 		private $_accessTokenUrl 	= 'http://api.twitter.com/oauth/access_token';
 		private $_signatureMethod 	= 'HMAC-SHA1';


### PR DESCRIPTION
Hi Elliott, 

The change is regarding the "authenticate" url vs. the "authorize" url which is the current method you have implemented. While using the later works, if a user has already "authed" in their account each time they are prompted to "Allow" twitter access... when using Twitter connect for signin this is an nuisance and detracts from the user experience. Hopefully you'll agree and this change is helpful 

Cheers, BN