### PR TITLE
http_query_string instead of manually construct url

### DIFF
--- a/application/libraries/tweet.php
+++ b/application/libraries/tweet.php
@@ -96,14 +96,7 @@
 		{
 			if ( count($params['request']) > 0 )
 			{
-				$url .= '?';
-			
-				foreach( $params['request'] as $k => $v )
-				{
-					$url .= "{$k}={$v}&";
-				}
-				
-				$url = substr($url, 0, -1);
+				$url = http_build_query($params);
 			}
 			
 			$this->_initConnection($url);
@@ -114,15 +107,7 @@
 		
 		public function post($url, $params)
 		{
-			// Todo
-			$post = '';
-			
-			foreach ( $params['request'] as $k => $v )
-			{
-				$post .= "{$k}={$v}&";
-			}
-			
-			$post = substr($post, 0, -1);
+			$post = http_build_query($params);
 			
 			$this->_initConnection($url, $params);
 			curl_setopt($this->_ch, CURLOPT_POST, 1);


### PR DESCRIPTION
Changed the manual url construction to use the http_query_string function of php, as proposed for the facebook library by nicholasruunu/codeigniter-facebook@18e4c2d81fec57f974d472fda441fbe107f8b763
