### PR TITLE
HTTPS endpoints

### DIFF
--- a/application/libraries/tweet.php
+++ b/application/libraries/tweet.php
@@ -277,9 +277,9 @@
 		
 		private $_obj;
 		private $_tokens = array();
-		private $_authorizationUrl 	= 'http://api.twitter.com/oauth/authorize';
-		private $_requestTokenUrl 	= 'http://api.twitter.com/oauth/request_token';
-		private $_accessTokenUrl 	= 'http://api.twitter.com/oauth/access_token';
+		private $_authorizationUrl 	= 'https://api.twitter.com/oauth/authorize';
+		private $_requestTokenUrl 	= 'https://api.twitter.com/oauth/request_token';
+		private $_accessTokenUrl 	= 'https://api.twitter.com/oauth/access_token';
 		private $_signatureMethod 	= 'HMAC-SHA1';
 		private $_version 			= '1.0';
 		private $_apiUrl 			= 'http://api.twitter.com';


### PR DESCRIPTION
Updated the URLs for the calls to Twitter as the user could be based on HTTPS with their profile, and this is just a safer fallback

Also, if the user is set to use HTTPS and the calls are made on HTTP, it gives a "invalid signature" error back on posts/gets that require a authenticated request. If the user's profile is HTTP and the calls are made to the HTTPS, there is a slight performance impact but doesn't break as in the other case
